### PR TITLE
accept context options from neaty-compoent-passport

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -53,7 +53,7 @@ function WechatStrategy(options, verify) {
  */
 util.inherits(WechatStrategy, passport.Strategy);
 
-WechatStrategy.prototype.authenticate = function (req) {
+WechatStrategy.prototype.authenticate = function (req, options) {
 
     if (!req._passport) {
         return this.error(new Error('passport.initialize() middleware not in use'));
@@ -121,7 +121,11 @@ WechatStrategy.prototype.authenticate = function (req) {
         });
     } else {
 
-        var location = self._oauth.getAuthorizeURL(self._callbackURL, req.query.state || self._state, self._scope);
+        var location = self._oauth.getAuthorizeURL(
+            options.callbackURL || self._callbackURL,
+            options.state || self._state,
+            options.scope || self._scope);
+
         debug('redirect authorizeURL -> \n%s', location);
         self.redirect(location, 302);
     }


### PR DESCRIPTION
passport(neaty-component-passport) will past the options argument to strategy(passport-wechat2), and it can be dynamically decide the scope of current request.
